### PR TITLE
feat: add request body support and middleware for automatic logging

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -25,4 +25,19 @@ describe('curlify', () => {
 
     expect(returned).toBe('curl -X POST http://api.something.com/')
   });
+
+  it('Should parse the request with body', async () => {
+    nock('http://api.something.com')
+      .post('/')
+      .reply(201, { ok: true })
+
+    const response = await request('http://api.something.com')
+      .post('/')
+      .send({ foo: 'bar' })
+      .expect(201)
+
+    const returned = curlify(response)
+
+    expect(returned).toBe("curl -X POST http://api.something.com/ \\\n\t-d '{\"foo\":\"bar\"}' \\\n\t-H \"Content-Type: application/json\"")
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export function curlify(response: Response): string {
     request: {
       method,
       url,
+      // @ts-ignore
+      _data: body,
     },
   } = response
 
@@ -12,9 +14,20 @@ export function curlify(response: Response): string {
     `curl -X ${method.toUpperCase()} ${url}`,
   ]
 
+  if (body && Object.keys(body).length > 0) {
+    lines.push(`-d '${JSON.stringify(body)}'`)
+    lines.push('-H "Content-Type: application/json"')
+  }
+
   return lines
-    .join('\\\n\t')
+    .join(' \\\n\t')
     .trim();
+}
+
+export function curlifyMiddleware(req: any) {
+  req.on('response', (res: any) => {
+    console.log(curlify(res))
+  })
 }
 
 export default curlify


### PR DESCRIPTION
- Extract request body from supertest internal _data property
- Include -d flag and Content-Type header in generated curl command when body is present
- Implement curlifyMiddleware for easy integration via supertest .use()
- Add test case to verify curl generation with request body
